### PR TITLE
OPS-951 Fix bug in Novell LDAP connector that can cause a thread to crash because of an unhandled exception.

### DIFF
--- a/mcs/class/Novell.Directory.Ldap/Novell.Directory.Ldap/ChangeLog
+++ b/mcs/class/Novell.Directory.Ldap/Novell.Directory.Ldap/ChangeLog
@@ -1,3 +1,7 @@
+2013-26-08 Pete Erickson  <petee@mindtouch.com>
+	Connection.cs: Catch ObjectDisposed exception which can happen if thread is aborted while reader 
+	is still reading.
+
 2009-05-07 Gonzalo Paniagua Javier <gonzalo@novell.com>
 
 	* Connection.cs: if the socket is already disconnected, Shutdown will

--- a/mcs/class/Novell.Directory.Ldap/Novell.Directory.Ldap/Connection.cs
+++ b/mcs/class/Novell.Directory.Ldap/Novell.Directory.Ldap/Connection.cs
@@ -1544,15 +1544,10 @@ namespace Novell.Directory.Ldap
 					// before closing sockets, from shutdown
 					return;
 				}
-#if TARGET_JVM
 				catch (ObjectDisposedException)
 				{
-					// we do not support Thread.Abort under java
-					// so we close the stream and the working thread
-					// catches ObjectDisposedException exception
 					return;
 				}
-#endif
 				catch (System.IO.IOException ioe)
 				{
 					


### PR DESCRIPTION
- remove the ifdef so we catch ObjectDisposedException.  This can happen if the connection is closed while the reader thread is performing a read operation.

We ship our own version of Novell.Diretory.Ldap.dll in deki's src/redist so this pull isn't really necessary.  I'll also submit a bug/patch upstream.
